### PR TITLE
[JENKINS-57880] Feature add unique name

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabserver/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserver/servers/GitLabServer.java
@@ -68,7 +68,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     };
 
     /**
-     * A unique name to use to identify the end-point.
+     * A unique name used to identify the endpoint.
      */
     @Nonnull
     private final String name;
@@ -101,7 +101,7 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     /**
      * {@inheritDoc}
      */
-    @CheckForNull
+    @Nonnull
     public String getName() {
         return name;
     }

--- a/src/main/java/io/jenkins/plugins/gitlabserver/servers/GitLabServer.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserver/servers/GitLabServer.java
@@ -99,27 +99,6 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     }
 
     /**
-     * Constructor
-     *
-     * @param name          A unique name to use to describe the end-point, if empty replaced with a random name
-     * @param serverUrl     The URL of this GitLab Server
-     * @param manageHooks   {@code true} if and only if Jenkins is supposed to auto-manage hooks for this end-point.
-     * @param credentialsId The {@link StandardUsernamePasswordCredentials#getId()} of the credentials to use for
-     *                      auto-management of hooks.
-     * @since 1.0.5
-     */
-    @DataBoundConstructor
-    public GitLabServer(@Nonnull String name, @NonNull String serverUrl, boolean manageHooks,
-                        @CheckForNull String credentialsId) {
-        this.manageHooks = manageHooks;
-        this.credentialsId = credentialsId;
-        this.serverUrl = defaultIfBlank(serverUrl, GITLAB_SERVER_URL);
-        this.name = StringUtils.isBlank(name)
-                ? getRandomName()
-                : name;
-    }
-
-    /**
      * {@inheritDoc}
      */
     @CheckForNull
@@ -154,6 +133,26 @@ public class GitLabServer extends AbstractDescribableImpl<GitLabServer> {
     @CheckForNull
     public String getCredentialsId() {
         return credentialsId;
+    }
+
+    /**
+     * Data Bound Constructor
+     *
+     * @param name          A unique name to use to describe the end-point, if empty replaced with a random name
+     * @param serverUrl     The URL of this GitLab Server
+     * @param manageHooks   {@code true} if and only if Jenkins is supposed to auto-manage hooks for this end-point.
+     * @param credentialsId The {@link StandardUsernamePasswordCredentials#getId()} of the credentials to use for
+     *                      auto-management of hooks.
+     */
+    @DataBoundConstructor
+    public GitLabServer(@Nonnull String name, @NonNull String serverUrl, boolean manageHooks,
+                        @CheckForNull String credentialsId) {
+        this.manageHooks = manageHooks;
+        this.credentialsId = credentialsId;
+        this.serverUrl = defaultIfBlank(serverUrl, GITLAB_SERVER_URL);
+        this.name = StringUtils.isBlank(name)
+                ? getRandomName()
+                : name;
     }
 
     /**

--- a/src/main/java/io/jenkins/plugins/gitlabserver/servers/GitLabServers.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserver/servers/GitLabServers.java
@@ -178,5 +178,4 @@ public class GitLabServers extends GlobalConfiguration {
         setServers(endpoints);
         return modified;
     }
-
 }

--- a/src/main/java/io/jenkins/plugins/gitlabserver/servers/GitLabServers.java
+++ b/src/main/java/io/jenkins/plugins/gitlabserver/servers/GitLabServers.java
@@ -98,6 +98,11 @@ public class GitLabServers extends GlobalConfiguration {
         return Messages.GitLabServers_displayName();
     }
 
+    /**
+     * Gets descriptor of {@link GitLabPersonalAccessTokenCreator}
+     *
+     * returns the list of descriptors
+     */
     public List<Descriptor> actions() {
         return Collections.singletonList(Jenkins.getInstance().getDescriptor(GitLabPersonalAccessTokenCreator.class));
     }

--- a/src/main/resources/io/jenkins/plugins/gitlabserver/servers/GitLabServer/config.groovy
+++ b/src/main/resources/io/jenkins/plugins/gitlabserver/servers/GitLabServer/config.groovy
@@ -3,12 +3,13 @@ package io.jenkins.plugins.gitlabserver.servers.GitLabServer
 import io.jenkins.plugins.gitlabserver.servers.GitLabServer
 import lib.FormTagLib
 import lib.CredentialsTagLib
+import org.apache.commons.lang.RandomStringUtils
 
 def f = namespace(FormTagLib)
 def c = namespace(CredentialsTagLib)
 
-f.entry(title: _("Name"), field: "name", "description": "A name for the connection") {
-    f.textbox()
+f.entry(title: _("Name"), field: "name", "description": "A unique name for the connection") {
+    f.textbox(default: String.format("gitlab-%s", RandomStringUtils.randomNumeric(GitLabServer.SHORT_NAME_LENGTH)))
 }
 
 f.entry(title: _("Server URL"), field: "serverUrl", "description": "The url to the GitLab server") {

--- a/src/main/resources/io/jenkins/plugins/gitlabserver/servers/GitLabServer/help-name.html
+++ b/src/main/resources/io/jenkins/plugins/gitlabserver/servers/GitLabServer/help-name.html
@@ -1,3 +1,3 @@
 <div>
-    A human friendly name for this GitLab server.
+    A human friendly and unique name for this GitLab server. If left blank, generates a unique default name.
 </div>


### PR DESCRIPTION
* The GitLabServers filter is based on a unique name given to the server at Global Configuration. Gitea Plugin does it based on `serverUrl` but user may sometimes want to add multiple server configuration for the same `serverUrl`. So I have added a function which generates a random name for the GitLabServer. User may change the name, but if user want to change it to a name that already exists there isn't a way to prevent it. This will cause problems when calling `removeServer`, `updateServer` methods.  You may take a look at the issue to learn more why checking is not possible. For now this is a viable solution, as user will rarely want to change the gitlab server name. 

* Also added a `removeServer` method which can be used to remove server from configuration based on GitLabServer name.