### PR TITLE
[JENKINS-57948] Use regex to compare gitlab server name field

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,12 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-matchers</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
             <version>${jcasc.version}</version>

--- a/src/test/java/io/jenkins/plugins/gitlabserver/casc/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabserver/casc/ConfigurationAsCodeTest.java
@@ -11,9 +11,6 @@ import io.jenkins.plugins.gitlabserver.credentials.PersonalAccessTokenImpl;
 import io.jenkins.plugins.gitlabserver.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserver.servers.GitLabServers;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
-import java.io.StringReader;
 import java.util.Collections;
 import java.util.List;
 import org.junit.ClassRule;

--- a/src/test/java/io/jenkins/plugins/gitlabserver/casc/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabserver/casc/ConfigurationAsCodeTest.java
@@ -10,7 +10,6 @@ import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.gitlabserver.credentials.PersonalAccessTokenImpl;
 import io.jenkins.plugins.gitlabserver.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserver.servers.GitLabServers;
-
 import java.util.Collections;
 import java.util.List;
 import org.junit.ClassRule;

--- a/src/test/java/io/jenkins/plugins/gitlabserver/casc/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabserver/casc/ConfigurationAsCodeTest.java
@@ -10,11 +10,16 @@ import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.gitlabserver.credentials.PersonalAccessTokenImpl;
 import io.jenkins.plugins.gitlabserver.servers.GitLabServer;
 import io.jenkins.plugins.gitlabserver.servers.GitLabServers;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.StringReader;
 import java.util.Collections;
 import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import static com.jcabi.matchers.RegexMatchers.matchesPattern;
 import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
 import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
 import static io.jenkins.plugins.casc.misc.Util.toYamlString;
@@ -35,7 +40,7 @@ public class ConfigurationAsCodeTest {
         assertThat(servers.size(), is(1));
         GitLabServer server = servers.get(0);
         assertThat(server.getServerUrl(), is("https://gitlab.com"));
-        assertThat(server.getName(), is("gitlab.com"));
+//        assertThat(server.getName(), matchesPattern("gitlab-*"));
         assertThat(server.isManageHooks(), is(true));
 
         List<PersonalAccessTokenImpl> credentials = CredentialsProvider.lookupCredentials(
@@ -58,6 +63,6 @@ public class ConfigurationAsCodeTest {
 
         String expected = toStringFromYamlFile(this, "expected_output.yml");
 
-        assertThat(exported, is(expected));
+        assertThat(exported, matchesPattern(expected));
     }
 }

--- a/src/test/java/io/jenkins/plugins/gitlabserver/casc/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/gitlabserver/casc/ConfigurationAsCodeTest.java
@@ -40,7 +40,7 @@ public class ConfigurationAsCodeTest {
         assertThat(servers.size(), is(1));
         GitLabServer server = servers.get(0);
         assertThat(server.getServerUrl(), is("https://gitlab.com"));
-//        assertThat(server.getName(), matchesPattern("gitlab-*"));
+        assertThat(server.getName(), matchesPattern("gitlab-[0-9]{4}"));
         assertThat(server.isManageHooks(), is(true));
 
         List<PersonalAccessTokenImpl> credentials = CredentialsProvider.lookupCredentials(

--- a/src/test/resources/io/jenkins/plugins/gitlabserver/casc/configuration-as-code.yml
+++ b/src/test/resources/io/jenkins/plugins/gitlabserver/casc/configuration-as-code.yml
@@ -12,5 +12,4 @@ unclassified:
     servers:
       - credentialsId: "i<3GitLab"
         manageHooks: true
-        name: "gitlab.com"
         serverUrl: "https://gitlab.com"

--- a/src/test/resources/io/jenkins/plugins/gitlabserver/casc/expected_output.yml
+++ b/src/test/resources/io/jenkins/plugins/gitlabserver/casc/expected_output.yml
@@ -1,5 +1,5 @@
 servers:
 - credentialsId: "i<3GitLab"
   manageHooks: true
-  name: "gitlab.com"
+  name: "gitlab-[0-9]{4}"
   serverUrl: "https://gitlab.com"


### PR DESCRIPTION
The server config `name` field is not populated via the config as code yaml. A random name is generated and the use `matchesPattern` to assert is `expected_output` is equal to `actual_output`.