### PR TITLE
Fix `RequireUpperBoundDeps`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,31 @@
             <version>3.10.0</version>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <!-- To avoid RequireUpperBoundDeps errors -->
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>structs</artifactId>
+                <version>1.18</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.3</version>
+            </dependency>
+            <dependency>
+                <groupId>joda-time</groupId>
+                <artifactId>joda-time</artifactId>
+                <version>2.9.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>junit</artifactId>
+                <version>1.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <developers>
         <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
-            <version>2.4.1</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
@@ -64,7 +64,11 @@
             <artifactId>javax.servlet-api</artifactId>
             <version>4.0.1</version>
         </dependency>
-
+        <dependency>
+            <groupId>com.damnhandy</groupId>
+            <artifactId>handy-uri-templates</artifactId>
+            <version>2.1.6</version>
+        </dependency>
 
         <dependency>
             <groupId>org.mockito</groupId>
@@ -96,6 +100,11 @@
             <version>${jcasc.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>git</artifactId>
+            <version>3.10.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
https://groups.google.com/d/msg/jenkinsci-dev/ZkVo4S69Xzg/I5EIC2oIBgAJ

Updated dependencies just like https://gist.github.com/baymac/ec349eda7166e93edc2269bb61ea9e94 removing `<exclusions>`, and added `<dependencyManagement>` to resolve `RequireUpperBoundDeps`:

```
[WARNING] Rule 5: org.apache.maven.plugins.enforcer.RequireUpperBoundDeps failed with message:
Failed while enforcing RequireUpperBoundDeps. The error(s) are [
Require upper bound dependencies error for org.jenkins-ci.plugins:structs:1.9 paths to dependency are:
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:scm-api:2.4.0
    +-org.jenkins-ci.plugins:structs:1.9
and
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:credentials:2.2.0
    +-org.jenkins-ci.plugins:structs:1.7
and
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:git:3.10.0
    +-org.jenkins-ci.plugins:structs:1.18
and
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:git:3.10.0
    +-org.jenkins-ci.plugins:git-client:2.7.7
      +-org.jenkins-ci.plugins:structs:1.9
and
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:git:3.10.0
    +-org.jenkins-ci.plugins.workflow:workflow-step-api:2.13
      +-org.jenkins-ci.plugins:structs:1.5
,
Require upper bound dependencies error for org.apache.httpcomponents:httpclient:4.5 paths to dependency are:
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-io.jenkins.plugins:gitlab-api:1.0.2
    +-org.gitlab4j:gitlab4j-api:4.11.4
      +-org.glassfish.jersey.connectors:jersey-apache-connector:2.28
        +-org.apache.httpcomponents:httpclient:4.5
and
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:git:3.10.0
    +-org.jenkins-ci.plugins:git-client:2.7.7
      +-org.jenkins-ci.plugins:apache-httpcomponents-client-4-api:4.5.3-2.0
        +-org.apache.httpcomponents:httpclient:4.5.3
and
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:git:3.10.0
    +-org.jenkins-ci.plugins:git-client:2.7.7
      +-org.jenkins-ci.plugins:apache-httpcomponents-client-4-api:4.5.3-2.0
        +-org.apache.httpcomponents:httpmime:4.5.3
          +-org.apache.httpcomponents:httpclient:4.5.3
and
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:git:3.10.0
    +-org.jenkins-ci.plugins:git-client:2.7.7
      +-org.jenkins-ci.plugins:apache-httpcomponents-client-4-api:4.5.3-2.0
        +-org.apache.httpcomponents:fluent-hc:4.5.3
          +-org.apache.httpcomponents:httpclient:4.5.3
and
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:git:3.10.0
    +-org.jenkins-ci.plugins:git-client:2.7.7
      +-org.jenkins-ci.plugins:apache-httpcomponents-client-4-api:4.5.3-2.0
        +-org.apache.httpcomponents:httpclient-cache:4.5.3
          +-org.apache.httpcomponents:httpclient:4.5.3
,
Require upper bound dependencies error for joda-time:joda-time:2.9.4 paths to dependency are:
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-com.damnhandy:handy-uri-templates:2.1.6
    +-joda-time:joda-time:2.9.4
and
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:git:3.10.0
    +-joda-time:joda-time:2.9.5
,
Require upper bound dependencies error for org.jenkins-ci.plugins:junit:1.2 paths to dependency are:
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:git:3.10.0
    +-org.jenkins-ci.plugins:matrix-project:1.7.1
      +-org.jenkins-ci.plugins:junit:1.2
and
+-io.jenkins.plugins:gitlab-branch-source:0.0.3.-SNAPSHOT
  +-org.jenkins-ci.plugins:git:3.10.0
    +-org.jenkins-ci.plugins:mailer:1.18
      +-org.jenkins-ci.plugins:display-url-api:0.2
        +-org.jenkins-ci.plugins:junit:1.3
]
```

Please attach full outputs from maven if this doesn't work on your environment.
