### PR TITLE
[JENKINS-58266, 58269, 58455] Hotfix/Subgroups

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
@@ -6,7 +6,6 @@ import hudson.Extension;
 import hudson.model.Item;
 import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
-import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
 import java.io.IOException;
 import java.util.Date;
 import jenkins.scm.api.SCMFile;
@@ -16,7 +15,6 @@ import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.SCMSourceDescriptor;
 import org.gitlab4j.api.GitLabApi;
-import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.models.Project;
 
 public class GitLabSCMFileSystem extends SCMFileSystem {
@@ -87,33 +85,17 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
             return null;
         }
 
-        @Override
-        public SCMFileSystem build(@NonNull SCMSource source, @NonNull SCMHead head, @CheckForNull SCMRevision rev)
+        public SCMFileSystem build(@NonNull SCMHead head, @CheckForNull SCMRevision rev, @NonNull GitLabApi gitLabApi, @NonNull Project gitlabProject)
                 throws IOException, InterruptedException {
-            GitLabSCMSource src = (GitLabSCMSource) source;
-            String projectPath;
             String ref;
             if (head instanceof MergeRequestSCMHead) {
-                projectPath = ((MergeRequestSCMHead) head).getOriginProjectPath();
                 ref = ((MergeRequestSCMHead) head).getOriginName();
             } else if (head instanceof BranchSCMHead) {
-                projectPath = src.getProjectPath();
                 ref = head.getName();
             } else {
                 return null;
             }
-            GitLabApi gitLabApi = null;
-            try {
-                gitLabApi = GitLabHelper.apiBuilder(src.getServerName());
-            } catch (NoSuchFieldException e) {
-                e.printStackTrace();
-            }
-            // TODO needs review
-            try {
-                return new GitLabSCMFileSystem(gitLabApi, gitLabApi.getProjectApi().getProject(projectPath), ref, rev);
-            } catch (GitLabApiException e) {
-                throw new IOException(e);
-            }
+            return new GitLabSCMFileSystem(gitLabApi, gitlabProject, ref, rev);
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -203,7 +203,7 @@ public class GitLabSCMNavigator extends SCMNavigator {
                 }
                 observer.getListener().getLogger().format("%nChecking project %s%n",
                         HyperlinkNote.encodeTo(p.getWebUrl(), p.getName()));
-                if (request.process(p.getName(), new SCMNavigatorRequest.SourceLambda() {
+                if (request.process(p.getPathWithNamespace(), new SCMNavigatorRequest.SourceLambda() {
                     @NonNull
                     @Override
                     public SCMSource create(@NonNull String projectName) throws IOException, InterruptedException {
@@ -243,9 +243,8 @@ public class GitLabSCMNavigator extends SCMNavigator {
     protected List<Action> retrieveActions(@NonNull SCMNavigatorOwner owner, SCMNavigatorEvent event,
                                            @NonNull TaskListener listener) throws IOException, InterruptedException {
         LOGGER.info("retrieving actions..");
-        GitLabApi gitLabApi = null;
         try {
-            gitLabApi = GitLabHelper.apiBuilder(serverName);
+            GitLabApi gitLabApi = GitLabHelper.apiBuilder(serverName);
             if (this.gitlabOwner == null) {
                 gitlabOwner = GitLabOwner.fetchOwner(gitLabApi, projectOwner);
             }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.AbstractGitSCMSource;
 import jenkins.scm.api.SCMFile;
@@ -216,8 +217,9 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     if (gitlabProject.getForkedFromProject() == null) {
                         listener.getLogger()
                                 .format("%nUnable to detect if it is a mirror or not still fetching MRs anyway...%n");
-                        // TODO Fix this: cannot call getDiffRefs on requests since it will always return null
-                        request.setMergeRequests(gitLabApi.getMergeRequestApi().getMergeRequests(gitlabProject));
+                        List<MergeRequest> mrs = gitLabApi.getMergeRequestApi().getMergeRequests(gitlabProject);
+                        mrs = mrs.stream().filter(mr -> mr.getSourceProjectId() != null).collect(Collectors.toList());
+                        request.setMergeRequests(mrs);
                     }
                     else {
                         listener.getLogger().format("%nIgnoring merge requests as project is a mirror...%n");

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -154,10 +154,6 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
             throws IOException, InterruptedException {
         try {
             GitLabApi gitLabApi = apiBuilder(serverName);
-            // To verify the supplied PAT is valid
-            if(!gitLabApi.getAuthToken().equals("")) {
-                gitLabApi.getUserApi().getCurrentUser();
-            }
             LOGGER.info(String.format("h, l..%s", Thread.currentThread().getName()));
             if(head instanceof BranchSCMHead) {
                 listener.getLogger().format("Querying the current revision of branch %s...%n", head.getName());
@@ -202,10 +198,6 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                             @NonNull TaskListener listener) throws IOException, InterruptedException {
         try {
             GitLabApi gitLabApi = apiBuilder(serverName);
-            // To verify the supplied PAT is valid
-            if (!gitLabApi.getAuthToken().equals("")) {
-                gitLabApi.getUserApi().getCurrentUser();
-            }
             if(gitlabProject == null) {
                 gitlabProject = gitLabApi.getProjectApi().getProject(projectPath);
             }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceBuilder.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceBuilder.java
@@ -17,8 +17,8 @@ public class GitLabSCMSourceBuilder extends SCMSourceBuilder<GitLabSCMSourceBuil
 
     public GitLabSCMSourceBuilder(@CheckForNull String id, @CheckForNull String serverName,
                                   @CheckForNull String credentialsId, @NonNull String projectOwner,
-                                  @NonNull String projectName) {
-        super(GitLabSCMSource.class, projectName);
+                                  @NonNull String projectPath) {
+        super(GitLabSCMSource.class, projectPath);
         this.id = id;
         this.serverName = serverName;
         this.projectOwner = projectOwner;

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/MergeRequestSCMHead.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/MergeRequestSCMHead.java
@@ -12,31 +12,31 @@ public class MergeRequestSCMHead extends SCMHead implements ChangeRequestSCMHead
     private final ChangeRequestCheckoutStrategy strategy;
     private final String originName;
     private final String originOwner;
-    private String originProject;
+    private String originProjectPath;
     private final SCMHeadOrigin origin;
 
     /**
      * Constructor.
      *
-     * @param id               the merge request id.
-     * @param name             the name of the head.
-     * @param target           the target of this merge request.
-     * @param strategy         the checkout strategy
-     * @param origin           the origin of the merge request
-     * @param originOwner      the name of the owner of the origin project
-     * @param originProject the name of the origin project
-     * @param originName       the name of the branch in the origin project
+     * @param id                the merge request id.
+     * @param name              the name of the head.
+     * @param target            the target of this merge request.
+     * @param strategy          the checkout strategy
+     * @param origin            the origin of the merge request
+     * @param originOwner       the name of the owner of the origin project
+     * @param originProjectPath the name of the origin project path
+     * @param originName        the name of the branch in the origin project
      */
     public MergeRequestSCMHead(@NonNull String name, long id, BranchSCMHead target,
                               ChangeRequestCheckoutStrategy strategy, SCMHeadOrigin origin, String originOwner,
-                              String originProject, String originName) {
+                              String originProjectPath, String originName) {
         super(name);
         this.id = id;
         this.target = target;
         this.strategy = strategy;
         this.origin = origin;
         this.originOwner = originOwner;
-        this.originProject = originProject;
+        this.originProjectPath = originProjectPath;
         this.originName = originName;
     }
 
@@ -79,8 +79,8 @@ public class MergeRequestSCMHead extends SCMHead implements ChangeRequestSCMHead
         return originOwner;
     }
 
-    public String getOriginProject() {
-        return originProject;
+    public String getOriginProjectPath() {
+        return originProjectPath;
     }
 
 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabHelper.java
@@ -21,7 +21,7 @@ public class GitLabHelper {
 
     public static String getServerUrlFromName(String serverName) {
         GitLabServer server = GitLabServers.get().findServer(serverName);
-        return server != null ? server.getServerUrl() : "";
+        return server != null ? server.getServerUrl() : GitLabServer.GITLAB_SERVER_URL;
     }
 
 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabSCMPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabSCMPipelineStatusNotifier.java
@@ -127,7 +127,7 @@ public class GitLabSCMPipelineStatusNotifier {
         try {
             GitLabApi gitLabApi = GitLabHelper.apiBuilder(source.getServerName());
             gitLabApi.getCommitsApi().addCommitStatus(
-                    source.getProjectOwner()+'/'+source.getProject(),
+                    source.getProjectPath(),
                     hash,
                     state,
                     status);
@@ -216,7 +216,7 @@ public class GitLabSCMPipelineStatusNotifier {
                                 resolving.remove(job);
                             }
                             gitLabApi.getCommitsApi().addCommitStatus(
-                                    source.getProjectOwner()+'/'+source.getProject(),
+                                    source.getProjectPath(),
                                     hash,
                                     state,
                                     status);

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource/config-detail.jelly
@@ -8,12 +8,28 @@
         <c:select/>
     </f:entry>
     <f:entry title="${%Owner}" field="projectOwner">
-        <f:textbox/>
+        <f:textbox clazz="project-owner"/>
     </f:entry>
-    <f:entry title="${%Project}" field="project">
-        <f:select/>
+    <f:entry title="${%Projects}" field="projectPath">
+        <f:select clazz="project-path"/>
     </f:entry>
     <f:entry title="${%Behaviours}">
         <scm:traits field="traits"/>
     </f:entry>
+    <script>
+        // var projectOwner = document.getElementsByClassName('project-owner');
+        //
+        // var projectPath = document.getElementsByClassName('project-path');
+        //
+        // projectPath.addEventListener('change', function() {
+        //     var currentPath = projectPath.value;
+        //     for(var i = currentPath.length-1; i >= 0; i--) {
+        //         currentPath = currentPath.substring(0, currentPath.length-1);
+        //         if(currentPath[i] === '/') {
+        //             break;
+        //         }
+        //     }
+        //     projectOwner.item(0).value = currentPath;
+        // })
+    </script>
 </j:jelly>


### PR DESCRIPTION
I replaced the variable `projectName` with `projectPath`. The `projectPath` variable contains the path of the project with the namespace (<group>/<subgroup>/<projectName>).

Had to modify the UriTemplates, fixed `doFillProjectPathItems` in GitLabSCMSource, refractored credentials look up in `GitLabSCMSource`.

There is one problem though, it doesn't work when there is a Merge Request in the subgroup project. There is some issue with `BranchDiscoveryTrait`. I am yet to figure out the NPE.

![Screenshot from 2019-07-12 09-05-47](https://user-images.githubusercontent.com/23079344/61101441-60052180-a487-11e9-91a4-84b54aa2557d.png)
