### PR TITLE
[JENKINS-58265, 58309, 58467] Added Tag support and minor code refractory

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMBuilder.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMBuilder.java
@@ -82,7 +82,11 @@ public class GitLabSCMBuilder extends GitSCMBuilder<GitLabSCMBuilder> {
             MergeRequestSCMHead h = (MergeRequestSCMHead) head;
             withRefSpec("+refs/merge-requests/" + h.getId() + "/head:refs/remotes/@{remote}/" + head.getName());
             projectUrl = projectUrl(h.getOriginProjectPath());
-        } else {
+        } else if (head instanceof GitLabTagSCMHead) {
+            withRefSpec("+refs/tags/" + head.getName() + ":refs/tags/" + head.getName());
+            projectUrl = projectUrl(projectPath);
+        }  else {
+
             withRefSpec("+refs/heads/" + head.getName() + ":refs/remotes/@{remote}/" + head.getName());
             projectUrl = projectUrl(projectPath);
         }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
@@ -95,7 +95,7 @@ public class GitLabSCMFile extends SCMFile {
         try {
             return gitLabApi.getRepositoryFileApi().getRawFile(project, ref, getPath());
         } catch (GitLabApiException e) {
-            LOGGER.info("Jenkinfile Not found: "+ref);
+            LOGGER.info("Jenkinsfile Not found: "+ref);
         }
         return null;
     }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFile.java
@@ -95,7 +95,7 @@ public class GitLabSCMFile extends SCMFile {
         try {
             return gitLabApi.getRepositoryFileApi().getRawFile(project, ref, getPath());
         } catch (GitLabApiException e) {
-            e.printStackTrace();
+            LOGGER.info("Jenkinfile Not found: "+ref);
         }
         return null;
     }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
@@ -92,6 +92,8 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
                 ref = ((MergeRequestSCMHead) head).getOriginName();
             } else if (head instanceof BranchSCMHead) {
                 ref = head.getName();
+            } else if (head instanceof GitLabTagSCMHead){
+                ref = head.getName();
             } else {
                 return null;
             }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMFileSystem.java
@@ -8,6 +8,7 @@ import hudson.scm.SCM;
 import hudson.scm.SCMDescriptor;
 import java.io.IOException;
 import java.util.Date;
+import jenkins.plugins.git.GitTagSCMRevision;
 import jenkins.scm.api.SCMFile;
 import jenkins.scm.api.SCMFileSystem;
 import jenkins.scm.api.SCMHead;
@@ -33,6 +34,8 @@ public class GitLabSCMFileSystem extends SCMFileSystem {
                 this.ref = ((MergeRequestSCMRevision) rev).getOrigin().getHash();
             } else if (rev instanceof BranchSCMRevision) {
                 this.ref = ((BranchSCMRevision) rev).getHash();
+            } else if (rev instanceof GitTagSCMRevision){
+                this.ref = ((GitTagSCMRevision) rev).getHash();
             } else {
                 this.ref = ref;
             }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -372,7 +372,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                             throws IOException, InterruptedException {
                                         return createProbe(head, revision);
                                     }
-                                }, (SCMSourceRequest.Witness) (head1, revision, isMatch) -> {
+                                }, (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
                                     if (isMatch) {
                                         listener.getLogger().format("Met criteria%n");
                                     } else {
@@ -476,6 +476,19 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     mergeUrl
             ));
             result.add(new GitLabLink("icon-branch", mergeUrl));
+        } else if(head instanceof  GitLabTagSCMHead) {
+            String tagUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName)+'/'+projectPath)
+                    .path("tree")
+                    .path(UriTemplateBuilder.var("tag"))
+                    .build()
+                    .set("tag", ((GitLabTagSCMHead) head).getName())
+                    .expand();
+            result.add(new ObjectMetadataAction(
+                    null,
+                    null,
+                    tagUrl
+            ));
+            result.add(new GitLabLink("icon-branch", tagUrl));
         }
         return result;
     }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -187,6 +187,11 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     listener.getLogger().format("Merge request #%s is CLOSED%n", h.getId());
                     return null;
                 }
+            } else if(head instanceof  GitLabTagSCMHead) {
+                listener.getLogger().format("Querying the current revision of tag %s...%n", head.getName());
+                String revision = gitLabApi.getTagsApi().getTag(gitlabProject, head.getName()).getCommit().getId();
+                listener.getLogger().format("Current revision of tag %s is %s%n", head.getName(), revision);
+                return new GitTagSCMRevision((GitLabTagSCMHead) head, revision);
             } else {
                 listener.getLogger().format("Unknown head: %s of type %s%n", head.getName(), head.getClass().getName());
                 return null;
@@ -372,7 +377,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                             throws IOException, InterruptedException {
                                         return createProbe(head, revision);
                                     }
-                                }, (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
+                                }, (SCMSourceRequest.Witness) (head1, revision, isMatch) -> {
                                     if (isMatch) {
                                         listener.getLogger().format("Met criteria%n");
                                     } else {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -223,7 +223,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     if (gitlabProject.getForkedFromProject() == null) {
                         listener.getLogger()
                                 .format("%nUnable to detect if it is a mirror or not still fetching MRs anyway...%n");
-                        List<MergeRequest> mrs = gitLabApi.getMergeRequestApi().getMergeRequests(gitlabProject);
+                        List<MergeRequest> mrs = gitLabApi.getMergeRequestApi().getMergeRequests(gitlabProject, Constants.MergeRequestState.OPENED);
                         mrs = mrs.stream().filter(mr -> mr.getSourceProjectId() != null).collect(Collectors.toList());
                         request.setMergeRequests(mrs);
                     }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -483,12 +483,12 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     mergeUrl
             ));
             result.add(new GitLabLink("icon-branch", mergeUrl));
-        } else if(head instanceof  GitLabTagSCMHead) {
+        } else if(head instanceof GitLabTagSCMHead) {
             String tagUrl = UriTemplate.buildFromTemplate(GitLabHelper.getServerUrlFromName(serverName)+'/'+projectPath)
                     .path("tree")
                     .path(UriTemplateBuilder.var("tag"))
                     .build()
-                    .set("tag", ((GitLabTagSCMHead) head).getName())
+                    .set("tag", head.getName())
                     .expand();
             result.add(new ObjectMetadataAction(
                     null,

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -207,7 +207,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                             @NonNull TaskListener listener) throws IOException, InterruptedException {
         try {
             GitLabApi gitLabApi = apiBuilder(serverName);
-            if(gitlabProject == null) {
+            if (gitlabProject == null) {
                 gitlabProject = gitLabApi.getProjectApi().getProject(projectPath);
             }
             LOGGER.info(String.format("c, o, e, l..%s", Thread.currentThread().getName()));
@@ -225,11 +225,11 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     if (gitlabProject.getForkedFromProject() == null) {
                         listener.getLogger()
                                 .format("%nUnable to detect if it is a mirror or not still fetching MRs anyway...%n");
-                        List<MergeRequest> mrs = gitLabApi.getMergeRequestApi().getMergeRequests(gitlabProject, Constants.MergeRequestState.OPENED);
+                        List<MergeRequest> mrs = gitLabApi.getMergeRequestApi()
+                                .getMergeRequests(gitlabProject, Constants.MergeRequestState.OPENED);
                         mrs = mrs.stream().filter(mr -> mr.getSourceProjectId() != null).collect(Collectors.toList());
                         request.setMergeRequests(mrs);
-                    }
-                    else {
+                    } else {
                         listener.getLogger().format("%nIgnoring merge requests as project is a mirror...%n");
                     }
                 }
@@ -273,15 +273,17 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                     }
                     listener.getLogger().format("%n%d branches were processed%n", count);
                 }
-                if(request.isFetchMRs() && gitlabProject.getForkedFromProject() == null && !(request.getForkMRStrategies().isEmpty()
-                        && request.getOriginMRStrategies().isEmpty())) {
+                if (request.isFetchMRs() && gitlabProject.getForkedFromProject() == null &&
+                        !(request.getForkMRStrategies().isEmpty()
+                                && request.getOriginMRStrategies().isEmpty())) {
                     int count = 0;
                     listener.getLogger().format("%nChecking merge requests..%n");
                     Iterable<MergeRequest> mrs = request.getMergeRequests();
                     for (MergeRequest mr : mrs) {
                         // Since by default GitLab4j do not populate DiffRefs for a list of Merge Requests
                         // It is required to get the individual diffRef using the Iid.
-                        final MergeRequest m = gitLabApi.getMergeRequestApi().getMergeRequest(gitlabProject, mr.getIid());
+                        final MergeRequest m =
+                                gitLabApi.getMergeRequestApi().getMergeRequest(gitlabProject, mr.getIid());
                         count++;
                         listener.getLogger().format("%nChecking merge request %s%n",
                                 HyperlinkNote.encodeTo(
@@ -318,16 +320,16 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                     ),
                                     (SCMSourceRequest.RevisionLambda<MergeRequestSCMHead, MergeRequestSCMRevision>) head ->
                                             new MergeRequestSCMRevision(
-                                                head,
-                                                new BranchSCMRevision(
-                                                        head.getTarget(),
-                                                        m.getDiffRefs().getBaseSha()
-                                                ),
-                                                new BranchSCMRevision(
-                                                        new BranchSCMHead(head.getOriginName()),
-                                                        m.getDiffRefs().getHeadSha()
-                                                )
-                                    ),
+                                                    head,
+                                                    new BranchSCMRevision(
+                                                            head.getTarget(),
+                                                            m.getDiffRefs().getBaseSha()
+                                                    ),
+                                                    new BranchSCMRevision(
+                                                            new BranchSCMHead(head.getOriginName()),
+                                                            m.getDiffRefs().getHeadSha()
+                                                    )
+                                            ),
                                     this::createProbe,
                                     (SCMSourceRequest.Witness) (head, revision, isMatch) -> {
                                         if (isMatch) {
@@ -341,16 +343,15 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                         .format("%n%d merge requests were processed (query completed)%n", count);
                                 return;
                             }
-
                         }
                     }
                     listener.getLogger().format("%n%d merge requests were processed%n", count);
                 }
-                if(request.isFetchTags()) {
+                if (request.isFetchTags()) {
                     int count = 0;
                     listener.getLogger().format("%nChecking tags..%n");
                     Iterable<Tag> tags = request.getTags();
-                    for(Tag tag : tags) {
+                    for (Tag tag : tags) {
                         count++;
                         String tagName = tag.getName();
                         Long tagDate = tag.getCommit().getCommittedDate().getTime();
@@ -368,7 +369,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
 
                         );
                         GitLabTagSCMHead head = new GitLabTagSCMHead(tagName, tagDate);
-                        if(request.process(head, new GitTagSCMRevision(head, sha),
+                        if (request.process(head, new GitTagSCMRevision(head, sha),
                                 new SCMSourceRequest.ProbeLambda<GitLabTagSCMHead, GitTagSCMRevision>() {
                                     @NonNull
                                     @Override
@@ -383,9 +384,10 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                                     } else {
                                         listener.getLogger().format("Does not meet criteria%n");
                                     }
-                                }))
+                                })) {
                             listener.getLogger().format("%n%d tags were processed (query completed)%n", count);
-                        return;
+                            return;
+                        }
                     }
                     listener.getLogger().format("%n%d tags were processed (query completed)%n", count);
                 }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSourceRequest.java
@@ -16,41 +16,77 @@ import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadOrigin;
 import jenkins.scm.api.SCMSource;
 import jenkins.scm.api.mixin.ChangeRequestCheckoutStrategy;
-import jenkins.scm.api.mixin.TagSCMHead;
 import jenkins.scm.api.trait.SCMSourceRequest;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.models.Branch;
 import org.gitlab4j.api.models.MergeRequest;
+import org.gitlab4j.api.models.Tag;
 
 public class GitLabSCMSourceRequest extends SCMSourceRequest {
-
+    /**
+     * {@code true} if branch details need to be fetched.
+     */
     private final boolean fetchBranches;
+    /**
+     * {@code true} if tag details need to be fetched.
+     */
     private final boolean fetchTags;
+    /**
+     * {@code true} if origin merge requests need to be fetched.
+     */
     private final boolean fetchOriginMRs;
+    /**
+     * {@code true} if fork merge requests need to be fetched.
+     */
     private final boolean fetchForkMRs;
-
+    /**
+     * The {@link ChangeRequestCheckoutStrategy} to create for each origin merge request.
+     */
     @NonNull
     private final Set<ChangeRequestCheckoutStrategy> originMRStrategies;
+    /**
+     * The {@link ChangeRequestCheckoutStrategy} to create for each fork merge request.
+     */
     @NonNull
     private final Set<ChangeRequestCheckoutStrategy> forkMRStrategies;
+    /**
+     * The set of merge request numbers that the request is scoped to or {@code null} if the request is not limited.
+     */
     @CheckForNull
     private final Set<Long> requestedMergeRequestNumbers;
+    /**
+     * The set of origin branch names that the request is scoped to or {@code null} if the request is not limited.
+     */
     @CheckForNull
     private final Set<String> requestedOriginBranchNames;
+    /**
+     * The set of tag names that the request is scoped to or {@code null} if the request is not limited.
+     */
     @CheckForNull
     private final Set<String> requestedTagNames;
-
+    /**
+     * The pull request details or {@code null} if not {@link #isFetchMRs()}.
+     */
     @CheckForNull
     private Iterable<MergeRequest> mergeRequests;
+    /**
+     * The branch details or {@code null} if not {@link #isFetchBranches()}.
+     */
     @CheckForNull
     private Iterable<Branch> branches;
-
     /**
-     * The project collaborator names or {@code null} if not provided.
+     * The tag details or {@code null} if not {@link #isFetchTags()}.
+     */
+    @CheckForNull
+    private Iterable<Tag> tags;
+    /**
+     * The repository collaborator names or {@code null} if not provided.
      */
     @CheckForNull
     private Set<String> collaboratorNames;
-
+    /**
+     * A connection to the GitLab API or {@code null} if none established yet.
+     */
     @CheckForNull
     private GitLabApi gitLabApi;
 
@@ -86,7 +122,7 @@ public class GitLabSCMSourceRequest extends SCMSourceRequest {
                     if (SCMHeadOrigin.DEFAULT.equals(h.getOrigin())) {
                         branchNames.add(((MergeRequestSCMHead) h).getOriginName());
                     }
-                } else if (h instanceof TagSCMHead) { // TODO replace with concrete class when tag support added
+                } else if (h instanceof GitLabTagSCMHead) {
                     tagNames.add(h.getName());
                 }
             }
@@ -264,6 +300,27 @@ public class GitLabSCMSourceRequest extends SCMSourceRequest {
     public final void setBranches(@CheckForNull Iterable<Branch> branches) {
         this.branches = branches;
     }
+
+    /**
+     * Provides the requests with the tag details.
+     *
+     * @param tags the tag details.
+     */
+    public final void setTags(@CheckForNull Iterable<Tag> tags) {
+        this.tags = tags;
+    }
+
+    /**
+     * Returns the tag details or an empty list if either the request did not specify to {@link #isFetchTags()} ()}
+     * or if the tag details have not been provided by {@link #setTags(Iterable)} yet.
+     *
+     * @return the tag details (may be empty)
+     */
+    @NonNull
+    public final Iterable<Tag> getTags() {
+        return Util.fixNull(tags);
+    }
+
 
     // TODO Iterable<Tag> getTags() and setTags(...)
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabTagSCMHead.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabTagSCMHead.java
@@ -1,0 +1,25 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import jenkins.plugins.git.GitTagSCMHead;
+import jenkins.scm.api.mixin.TagSCMHead;
+
+public class GitLabTagSCMHead extends GitTagSCMHead implements TagSCMHead {
+    /**
+     * Constructor.
+     *
+     * @param name      the name.
+     * @param timestamp the tag timestamp;
+     */
+    public GitLabTagSCMHead(@NonNull String name, long timestamp) {
+        super(name, timestamp);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getPronoun() {
+        return Messages.GitLabTagSCMHead_Pronoun();
+    }
+}

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/TagDiscoveryTrait.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/TagDiscoveryTrait.java
@@ -1,0 +1,119 @@
+package io.jenkins.plugins.gitlabbranchsource;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import jenkins.plugins.git.GitTagSCMRevision;
+import jenkins.scm.api.SCMHeadCategory;
+import jenkins.scm.api.SCMHeadOrigin;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.trait.SCMHeadAuthority;
+import jenkins.scm.api.trait.SCMHeadAuthorityDescriptor;
+import jenkins.scm.api.trait.SCMSourceContext;
+import jenkins.scm.api.trait.SCMSourceRequest;
+import jenkins.scm.api.trait.SCMSourceTrait;
+import jenkins.scm.api.trait.SCMSourceTraitDescriptor;
+import jenkins.scm.impl.TagSCMHeadCategory;
+import jenkins.scm.impl.trait.Discovery;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * A {@link Discovery} trait for GitLab that will discover tags on the project.
+ */
+public class TagDiscoveryTrait extends SCMSourceTrait {
+    /**
+     * Constructor for stapler.
+     */
+    @DataBoundConstructor
+    public TagDiscoveryTrait() {
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void decorateContext(SCMSourceContext<?, ?> context) {
+        GitLabSCMSourceContext ctx = (GitLabSCMSourceContext) context;
+        ctx.wantTags(true);
+        ctx.withAuthority(new TagSCMHeadAuthority());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean includeCategory(@NonNull SCMHeadCategory category) {
+        return category instanceof TagSCMHeadCategory;
+    }
+
+    /**
+     * Our descriptor.
+     */
+    @Symbol("gitHubTagDiscovery")
+    @Extension
+    @Discovery
+    public static class DescriptorImpl extends SCMSourceTraitDescriptor {
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String getDisplayName() {
+            return Messages.TagDiscoveryTrait_displayName();
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSourceContext> getContextClass() {
+            return GitLabSCMSourceContext.class;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Class<? extends SCMSource> getSourceClass() {
+            return GitLabSCMSource.class;
+        }
+
+    }
+
+    /**
+     * Trusts tags from the origin project.
+     */
+    public static class TagSCMHeadAuthority extends SCMHeadAuthority<SCMSourceRequest, GitLabTagSCMHead, GitTagSCMRevision> {
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected boolean checkTrusted(@NonNull SCMSourceRequest request, @NonNull GitLabTagSCMHead head) {
+            return true;
+        }
+
+        /**
+         * Out descriptor.
+         */
+        @Extension
+        public static class DescriptorImpl extends SCMHeadAuthorityDescriptor {
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public String getDisplayName() {
+                return Messages.TagDiscoveryTrait_authorityDisplayName();
+            }
+
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public boolean isApplicableToOrigin(@NonNull Class<? extends SCMHeadOrigin> originClass) {
+                return SCMHeadOrigin.Default.class.isAssignableFrom(originClass);
+            }
+        }
+    }
+}
+

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabBrowser.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabBrowser.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.gitlabbranchsource.helpers;
 
 import com.damnhandy.uri.template.UriTemplate;
 import com.damnhandy.uri.template.UriTemplateBuilder;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.plugins.git.GitChangeSet;
@@ -81,6 +82,7 @@ public class GitLabBrowser extends GitRepositoryBrowser {
 
     @Extension
     public static class DescriptorImp extends Descriptor<RepositoryBrowser<?>> {
+        @NonNull
         public String getDisplayName() {
             return "GitLab";
         }

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabSCMPipelineStatusNotifier.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/helpers/GitLabSCMPipelineStatusNotifier.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import jenkins.plugins.git.GitTagSCMRevision;
 import jenkins.scm.api.SCMHead;
 import jenkins.scm.api.SCMHeadObserver;
 import jenkins.scm.api.SCMRevision;
@@ -113,8 +114,11 @@ public class GitLabSCMPipelineStatusNotifier {
             listener.getLogger().format("[GitLab Pipeline Status] Notifying merge request build status: %s %s%n",
                     status.getStatus(), status.getDescription());
             hash = ((MergeRequestSCMRevision) revision).getOrigin().getHash();
+        } else if (revision instanceof GitTagSCMRevision){
+            listener.getLogger().format("[GitLab Pipeline Status] Notifying tag build status: %s %s%n",
+                    status.getStatus(), status.getDescription());
+            hash = ((GitTagSCMRevision) revision).getHash();
         } else {
-            // TODO tags
             return;
         }
         JobScheduledListener jsl = ExtensionList.lookup(QueueListener.class).get(JobScheduledListener.class);
@@ -184,8 +188,10 @@ public class GitLabSCMPipelineStatusNotifier {
                         } else if (revision instanceof MergeRequestSCMRevision) {
                             LOGGER.log(Level.INFO, "Notifying merge request pending build {0}", job.getFullName());
                             hash = ((MergeRequestSCMRevision) revision).getOrigin().getHash();
+                        } else if (revision instanceof GitTagSCMRevision){
+                            LOGGER.log(Level.INFO, "Notifying tag pending build {0}", job.getFullName());
+                            hash = ((GitTagSCMRevision) revision).getHash();
                         } else {
-                            // TODO tags
                             return;
                         }
                         String url;

--- a/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/gitlabbranchsource/Messages.properties
@@ -12,6 +12,11 @@ ForkMergeRequestDiscoveryTrait.headAndMerge=Both the current merge request revis
 ForkMergeRequestDiscoveryTrait.headOnly=The current merge request revision
 ForkMergeRequestDiscoveryTrait.mergeOnly=Merging the merge request with the current target branch revision
 ForkMergeRequestDiscoveryTrait.nobodyDisplayName=Nobody
+
+GitLabTagSCMHead.Pronoun=Tag
+TagDiscoveryTrait.authorityDisplayName=Trust origin tags
+TagDiscoveryTrait.displayName=Discover tags
+GitLabSCMSource.TagCategory=Tags
 GitLabBrowser.displayName=GitLab
 GitLabLink.displayName=GitLab
 GitLabSCMNavigator.description=Scans a GitLab Group (or user account) for all projects matching some defined \


### PR DESCRIPTION
## Features:

* Impl `GitLabTagSCMHead`
* Impl `TagDiscoveryTrait`
* Removed extra API calls so faster branch indexing
* Added Tag refspecs in `GitLabSCMBuilder`
* Added Tag strings

## Bugs:

Unable to fetch tags:

Still figuring out the NPE.

![Screenshot from 2019-07-12 16-11-30](https://user-images.githubusercontent.com/23079344/61122962-c0648500-a4c0-11e9-9e7c-916857ab8f42.png)
<details>
<summary>See Text</summary>
Checking tag gitlab-branch-source-v0.0.3-SNAPSHOT
ERROR: [Fri Jul 12 14:22:07 IST 2019] Could not fetch branches from source fc1f3577-d743-43e9-b358-08be8518e2bc
java.lang.NullPointerException
	at java.util.Objects.requireNonNull(Objects.java:203)
	at io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource$2.close(GitLabSCMSource.java:536)
	at jenkins.scm.api.trait.SCMSourceRequest.process(SCMSourceRequest.java:350)
	at jenkins.scm.api.trait.SCMSourceRequest.process(SCMSourceRequest.java:249)
	at io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource.retrieve(GitLabSCMSource.java:298)
	at jenkins.scm.api.SCMSource._retrieve(SCMSource.java:373)
	at jenkins.scm.api.SCMSource.fetch(SCMSource.java:283)
	at jenkins.branch.MultiBranchProject.computeChildren(MultiBranchProject.java:631)
	at com.cloudbees.hudson.plugins.folder.computed.ComputedFolder.updateChildren(ComputedFolder.java:277)
	at com.cloudbees.hudson.plugins.folder.computed.FolderComputation.run(FolderComputation.java:164)
	at jenkins.branch.MultiBranchProject$BranchIndexing.run(MultiBranchProject.java:1022)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
[Fri Jul 12 14:22:07 IST 2019] Finished branch indexing. Indexing took 54 sec
FATAL: Failed to recompute children of asdas
java.lang.NullPointerException
	at java.util.Objects.requireNonNull(Objects.java:203)
	at io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource$2.close(GitLabSCMSource.java:536)
	at jenkins.scm.api.trait.SCMSourceRequest.process(SCMSourceRequest.java:350)
	at jenkins.scm.api.trait.SCMSourceRequest.process(SCMSourceRequest.java:249)
	at io.jenkins.plugins.gitlabbranchsource.GitLabSCMSource.retrieve(GitLabSCMSource.java:298)
	at jenkins.scm.api.SCMSource._retrieve(SCMSource.java:373)
	at jenkins.scm.api.SCMSource.fetch(SCMSource.java:283)
	at jenkins.branch.MultiBranchProject.computeChildren(MultiBranchProject.java:631)
	at com.cloudbees.hudson.plugins.folder.computed.ComputedFolder.updateChildren(ComputedFolder.java:277)
	at com.cloudbees.hudson.plugins.folder.computed.FolderComputation.run(FolderComputation.java:164)
	at jenkins.branch.MultiBranchProject$BranchIndexing.run(MultiBranchProject.java:1022)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
Finished: FAILURE
</details>