### PR TITLE
[JENKINS-58361, 57760] Feature/web-hook

### DIFF
--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMNavigator.java
@@ -319,7 +319,8 @@ public class GitLabSCMNavigator extends SCMNavigator {
         WebhookRegistration mode = new GitLabSCMSourceContext(null, SCMHeadObserver.none())
                 .withTraits(new GitLabSCMNavigatorContext().withTraits(traits).traits())
                 .webhookRegistration();
-        GitLabWebhookListener.register(owner, this, mode, credentialsId);
+        LOGGER.info(mode.toString());
+        GitLabWebhookListener.register(owner, this, mode);
     }
 
     public PersonalAccessToken credentials(SCMSourceOwner owner) {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -575,7 +575,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 .withTraits(new GitLabSCMNavigatorContext().withTraits(traits).traits())
                 .webhookRegistration();
         LOGGER.info("Mode of wh: " + mode.toString());
-        GitLabWebhookListener.register(getOwner(), this, mode);
+        GitLabWebhookListener.register(this, mode);
     }
 
     public PersonalAccessToken credentials() {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -574,6 +574,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
         WebhookRegistration mode = new GitLabSCMSourceContext(null, SCMHeadObserver.none())
                 .withTraits(new GitLabSCMNavigatorContext().withTraits(traits).traits())
                 .webhookRegistration();
+        LOGGER.info("Mode of wh: " + mode.toString());
         GitLabWebhookListener.register(getOwner(), this, mode, credentialsId);
     }
 

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabSCMSource.java
@@ -575,7 +575,7 @@ public class GitLabSCMSource extends AbstractGitSCMSource {
                 .withTraits(new GitLabSCMNavigatorContext().withTraits(traits).traits())
                 .webhookRegistration();
         LOGGER.info("Mode of wh: " + mode.toString());
-        GitLabWebhookListener.register(getOwner(), this, mode, credentialsId);
+        GitLabWebhookListener.register(getOwner(), this, mode);
     }
 
     public PersonalAccessToken credentials() {

--- a/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebhookListener.java
+++ b/src/main/java/io/jenkins/plugins/gitlabbranchsource/GitLabWebhookListener.java
@@ -1,7 +1,6 @@
 package io.jenkins.plugins.gitlabbranchsource;
 
 import com.damnhandy.uri.template.UriTemplate;
-import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabHelper;
 import io.jenkins.plugins.gitlabbranchsource.helpers.GitLabOwner;
 import io.jenkins.plugins.gitlabserverconfig.credentials.PersonalAccessToken;
 import io.jenkins.plugins.gitlabserverconfig.servers.GitLabServer;
@@ -12,12 +11,9 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import jenkins.model.JenkinsLocationConfiguration;
 import jenkins.scm.api.SCMNavigatorOwner;
-import jenkins.scm.api.SCMSourceOwner;
 import org.apache.commons.lang.StringUtils;
-import org.gitlab4j.api.Constants;
 import org.gitlab4j.api.GitLabApi;
 import org.gitlab4j.api.GitLabApiException;
-import org.gitlab4j.api.models.Group;
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.ProjectFilter;
 import org.gitlab4j.api.models.ProjectHook;
@@ -104,8 +100,8 @@ public class GitLabWebhookListener {
         }
     }
 
-    public static void register(SCMSourceOwner owner, GitLabSCMSource source,
-                                WebhookRegistration mode, String credentialsId) {
+    public static void register(GitLabSCMSource source,
+                                WebhookRegistration mode) {
         PersonalAccessToken credentials;
         GitLabServer server = GitLabServers.get().findServer(source.getServerName());
         if(server == null) {


### PR DESCRIPTION
## Fixes:

* Webhooks creation on GitLab Server for `Navigator` and `Source`.

![Screenshot from 2019-07-13 17-09-05](https://user-images.githubusercontent.com/23079344/61171176-8fa05080-a591-11e9-91af-3beb13519ed0.png)

## Issue:

* Unable to listen to post request on Jenkins instance. Any idea how to implement this?

* GitLab API doesn't support webhooks creation on a group. Although Group webhooks are available in Enterprise Edition but cannot take advantage of it. Currently it is a WIP in GitLab. So for Navigator, individually setting webhooks on all projects.